### PR TITLE
Github logic moved so no ugly re-render. Also handle 404 response 

### DIFF
--- a/frontend/src/components/StreamPost.jsx
+++ b/frontend/src/components/StreamPost.jsx
@@ -349,7 +349,7 @@ StreamPost.propTypes = {
 	visibleTo: PropTypes.array.isRequired,
 	unlisted: PropTypes.bool.isRequired,
 	
-	isGithub: PropTypes.string,
+	isGithub: PropTypes.bool,
 	origin: PropTypes.string.isRequired,
 	
 	author: PropTypes.string.isRequired,

--- a/frontend/src/pages/Stream.jsx
+++ b/frontend/src/pages/Stream.jsx
@@ -3,70 +3,13 @@ import StreamFeed from '../components/StreamFeed';
 import { SemanticToastContainer } from 'react-semantic-toasts';
 import store from '../store/index.js';
 import './styles/Stream.css';
-import HTTPFetchUtil from "../util/HTTPFetchUtil";
-import utils from "../util/utils";
-import Cookies from 'js-cookie';
 
 class Stream extends Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			github: '',
-		};	
-		this.fetchProfile = this.fetchProfile.bind(this);
-		this.getloggedinAuthorID = this.getloggedinAuthorID.bind(this);
-	};	
-	
-    getloggedinAuthorID() {
-        const cookieauthorid = Cookies.get("userID"),
-            storeauthorid = store.getState().loginReducers.userId;
-        let authorID;
-        if (cookieauthorid !== null) {
-            authorID = cookieauthorid;
-        } else if (storeauthorid !== null) {
-			authorID = storeauthorid;
-		}
-	return authorID;
-	}
-
-	fetchProfile() {
-		const authorID = this.getloggedinAuthorID();
-		const hostUrl = "/api/author/"+ utils.getShortAuthorId(authorID),
-				requireAuth = true;
-		HTTPFetchUtil.getRequest(hostUrl, requireAuth)
-				.then((httpResponse) => {
-						if (httpResponse.status === 200) {
-								httpResponse.json().then((results) => {
-									this.setState({
-										github: results.github,
-									});
-								})
-						} else {
-							throw new Error('Could not get github username');
-						}
-				})
-				.catch((error) => {
-						console.error(error);
-		});
-	}
-
-	componentDidMount() {
-		this.fetchProfile();
-	}
-		
 	render() {
 		const storeItems = store.getState().loginReducers;
 		return(	
 			<div className="pusher">
-				<h1 className="streamHeader"> Stream </h1>
-
-				{this.state.github
-				?
-				<StreamFeed storeItems={storeItems} githuburl={this.state.github} urlPath="/api/author/posts/" />
-				:
-				<StreamFeed storeItems={storeItems} urlPath="/api/author/posts/" />
-				}
-				
+				<StreamFeed storeItems={storeItems} getGithub={true} urlPath="/api/author/posts/" />
                 <SemanticToastContainer position="bottom-left"/>
 			</div>
 			)


### PR DESCRIPTION
Made it so no ugly rerender with github posts by moving fetchProfile logic into StreamFeed.

Added a check for 404 response due to non-existent github profiles. 

Tested with good github url, bad github url, and no github url