### PR TITLE
Loader issues

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -396,7 +396,7 @@
       }
     },
     "@babel/plugin-syntax-typescript": {
-      "version": "7.3.3",
+      "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
       "integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
       "requires": {
@@ -18209,7 +18209,7 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.3.4",
+          "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
           "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
           "requires": {

--- a/frontend/src/components/CommentsOnPost.jsx
+++ b/frontend/src/components/CommentsOnPost.jsx
@@ -152,14 +152,14 @@ class CommentsOnPost extends Component {
 				$commentSection = <p> No comments yet...</p>;
 			}
 		}
-		
 		return (
 			<span>
 				<Comment.Group>
 					<Header as='h3' dividing>
 						Comments
 					</Header>
-					<Loader active={this.state.isFetching} inverted/>
+					
+					{this.state.isFetching && <Loader active={this.state.isFetching} inverted/>}
 					{!this.state.isFetching && $commentSection}
 				</Comment.Group>
 				<Form>

--- a/frontend/src/components/CommentsOnPost.jsx
+++ b/frontend/src/components/CommentsOnPost.jsx
@@ -152,7 +152,7 @@ class CommentsOnPost extends Component {
 				$commentSection = <p> No comments yet...</p>;
 			}
 		}
-	
+		
 		return (
 			<span>
 				<Comment.Group>

--- a/frontend/src/components/StreamFeed.jsx
+++ b/frontend/src/components/StreamFeed.jsx
@@ -1,4 +1,6 @@
 import React, { Component} from 'react';
+import {connect} from 'react-redux';
+import * as FriendsActions from "../actions/FriendsActions";
 import { Button, Icon, Feed, Loader, Message} from 'semantic-ui-react';
 import StreamPost from '../components/StreamPost';
 import HTTPFetchUtil from '../util/HTTPFetchUtil.js';
@@ -9,6 +11,7 @@ import { toast } from 'react-semantic-toasts';
 import 'react-semantic-toasts/styles/react-semantic-alert.css';
 import utils from "../util/utils";
 import './styles/StreamFeed.css';
+import store from '../store/index.js';
 import Cookies from 'js-cookie';
 
 const controller = new AbortController();
@@ -88,6 +91,11 @@ class StreamFeed extends Component {
 		}
 		else {
 			this.getPosts();
+		}
+		if (window.location.pathname === "/stream") {
+			const storeItems = store.getState().loginReducers,
+				hostUrl = "/api/author/" + utils.getShortAuthorId(Cookies.get("userID") || storeItems.userId);
+			this.props.getCurrentApprovedFriends(hostUrl, true);
 		}
 	}
 	
@@ -318,4 +326,12 @@ StreamFeed.propTypes = {
 	getGithub: PropTypes.bool,
 }
 
-export default StreamFeed;
+const mapDispatchToProps = dispatch => {
+    return {
+        getCurrentApprovedFriends: (urlPath, requireAuth) => {
+            return dispatch(FriendsActions.getCurrentApprovedFriends(urlPath, requireAuth));
+		},
+    }
+};
+
+export default connect(null, mapDispatchToProps)(StreamFeed);

--- a/frontend/src/pages/Stream.jsx
+++ b/frontend/src/pages/Stream.jsx
@@ -1,17 +1,12 @@
 import React, { Component } from 'react';
-import {connect} from 'react-redux';
-import * as FriendsActions from "../actions/FriendsActions";
 import StreamFeed from '../components/StreamFeed';
 import { SemanticToastContainer } from 'react-semantic-toasts';
 import store from '../store/index.js';
-import Cookies from 'js-cookie';
 import './styles/Stream.css';
-import utils from "../util/utils";
 
 class Stream extends Component {
 	render() {
 		const storeItems = store.getState().loginReducers;
-		this.props.getCurrentApprovedFriends("/api/author/" + utils.getShortAuthorId(Cookies.get("userID") || storeItems.userId), true);
 		return(	
 			<div className="pusher">
 				<StreamFeed storeItems={storeItems} getGithub={true} urlPath="/api/author/posts/" />
@@ -21,12 +16,4 @@ class Stream extends Component {
     }
 }
 
-const mapDispatchToProps = dispatch => {
-    return {
-        getCurrentApprovedFriends: (urlPath, requireAuth) => {
-            return dispatch(FriendsActions.getCurrentApprovedFriends(urlPath, requireAuth));
-		},
-    }
-};
-
-export default connect(null, mapDispatchToProps)(Stream);
+export default (Stream);


### PR DESCRIPTION
Hiding our fetch friends request inside StreamFeed to happen every time we go to stream.

This makes the loader appear right away on stream again. 

Also added conditional render for comments loader. Should ensure loader does not appear forever on posts. 