### PR TITLE
unlisted post impossible to get bug

### DIFF
--- a/backend/api/tests/test_Post.py
+++ b/backend/api/tests/test_Post.py
@@ -747,3 +747,26 @@ class PostTestCase(TestCase):
         expected_author_list = [self.authorProfile1] * expected_output["count"]
         assert_post_response(response, expected_output, expected_author_list)
         self.client.logout()
+
+    def test_get_single_public_unlisted_post(self):
+        Post.objects.all().delete()
+
+        unlisted_input = self.public_post_1.copy()
+        unlisted_input["unlisted"] = True
+
+        test_post_obj = create_mock_post(unlisted_input, self.authorProfile2)
+
+        self.client.login(username=self.username1, password=self.password1)
+
+        response = self.client.get("/api/posts/{}".format(test_post_obj.id))
+
+        expected_output = {
+            "query": "posts",
+            "count": 1,
+            "posts": [unlisted_input]
+        }
+
+        expected_author_list = [self.authorProfile2] * expected_output["count"]
+        print(response.json())
+        assert_post_response(response, expected_output, expected_author_list)
+        self.client.logout()

--- a/backend/api/tests/test_Post.py
+++ b/backend/api/tests/test_Post.py
@@ -767,6 +767,5 @@ class PostTestCase(TestCase):
         }
 
         expected_author_list = [self.authorProfile2] * expected_output["count"]
-        print(response.json())
         assert_post_response(response, expected_output, expected_author_list)
         self.client.logout()

--- a/backend/api/view/CreatePostView.py
+++ b/backend/api/view/CreatePostView.py
@@ -195,7 +195,7 @@ class CreatePostView(generics.GenericAPIView):
             post = Post.objects.get(id=post_id)
             serialized_post = PostSerializer(post).data
 
-            if(not can_read(str(authorId), serialized_post, friend_list_data)):
+            if(not can_read(str(authorId), serialized_post, friend_list_data, True)):
 
                 return Response("Error: You do not have permission to view this post", status.HTTP_400_BAD_REQUEST)
             serialized_post_with_comments = build_post(serialized_post)

--- a/backend/api/view/Util.py
+++ b/backend/api/view/Util.py
@@ -18,12 +18,12 @@ def get_author_id(author_profile, escaped):
 
 # the post argument should be a serialized post object
 # the friends_list argument should be a list of author id
-def can_read(requesting_author_id, post, friends_list):
+def can_read(requesting_author_id, post, friends_list, ignore_unlisted=False):
     try:
         parsed_url = urlparse(requesting_author_id)
         requesting_author_host = '{}://{}/'.format(parsed_url.scheme, parsed_url.netloc)
 
-        if (post["unlisted"]):
+        if (not ignore_unlisted and post["unlisted"]):
             return False
 
         elif (requesting_author_id == post["author"]["id"] or post["visibility"] == "PUBLIC"):


### PR DESCRIPTION
fix so that unlisted post can be visible in /posts/<id> if user has permission