### PR TITLE
clear redux store on logout

### DIFF
--- a/frontend/src/actions/FriendsActions.js
+++ b/frontend/src/actions/FriendsActions.js
@@ -74,3 +74,12 @@ export const startFetching = () => {
                         })
            }
 }
+
+export const clearStore = () => {
+    return (dispatch) => {
+                        return dispatch({
+                            type: "CLEAR_STORE",
+                            payload: ''
+                        })
+           }
+}

--- a/frontend/src/actions/ProfileActions.js
+++ b/frontend/src/actions/ProfileActions.js
@@ -17,3 +17,12 @@ export const editProfile = (results) => {
 					});
 	}
 }
+
+export const clearStore = () => {
+    return (dispatch) => {
+                        return dispatch({
+                            type: "CLEAR_STORE",
+                            payload: ''
+                        })
+           }
+}

--- a/frontend/src/pages/Logout.jsx
+++ b/frontend/src/pages/Logout.jsx
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import {Redirect} from "react-router-dom";
 import Cookies from 'js-cookie';
 import * as LoginActions from "../actions/LoginActions";
+import * as FriendsActions from "../actions/FriendsActions";
+import * as ProfileActions from "../actions/ProfileActions";
 import {connect} from "react-redux";
 
 class Logout extends Component {
@@ -13,6 +15,8 @@ class Logout extends Component {
         Cookies.remove("displayName");
         Cookies.remove("userPass");
         this.props.sendLogout();
+        this.props.clearFriendStore();
+        this.props.clearProfileStore();
     }
 
 	render() {
@@ -26,7 +30,13 @@ const mapDispatchToProps = dispatch => {
     return {
         sendLogout: () => {
             return dispatch(LoginActions.sendLogout());
-        }
+        },
+        clearFriendStore: () => {
+        	return dispatch(FriendsActions.clearStore());
+        },
+        clearProfileStore: () => {
+        	return dispatch(ProfileActions.clearStore());
+        },
     }
 };
 

--- a/frontend/src/reducers/FriendsReducers.js
+++ b/frontend/src/reducers/FriendsReducers.js
@@ -27,6 +27,10 @@ export default function friendsReducer(state=initialState, action) {
         	return Object.assign({}, state, {
                 isFetching: true,
             });
+            
+        case "CLEAR_STORE":
+        	return Object.assign({}, state, initialState);
+                 
         default:
             return state;
     }

--- a/frontend/src/reducers/ProfileReducers.js
+++ b/frontend/src/reducers/ProfileReducers.js
@@ -8,6 +8,9 @@ export default function profileReducers(state=initialState,action) {
             return Object.assign({}, state, {
                 displayName: action.payload.displayName
               });
+		case "CLEAR_STORE":
+			return Object.assign({}, state, initialState);
+                 
         default:
             return '';
     }


### PR DESCRIPTION
Redux stores for Friends and Profiles reducers now cleared out on logout. 

Main issue was that friend request notifications started off as whatever the previous user had because it was using the same redux store.